### PR TITLE
Relicense to BSD-3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,9 +5,7 @@ Redistribution and use in source and binary forms, with or without modification,
 
 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software must display the following acknowledgement:
-	This product includes software developed by CoolStar.
-4. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
 THIS SOFTWARE IS PROVIDED BY COOLSTAR "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL COOLSTAR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 =========================================
@@ -20,5 +18,3 @@ jlaunchctl license: Free. Use it, by all means. And if you do find it useful, le
 	Likewise if you want a feature/command 
 
 =========================================
-
-NOTE: THIS LICENSE IS NOT COMPATIBLE WITH GPL AND CODE FROM THIS REPO MAY NOT BE MIXED WITH GPL LICENSED CODE


### PR DESCRIPTION
The advertising clause is difficult to comply with and is incompatible with the GPL.
Further information about why this clause is bad: https://www.gnu.org/licenses/bsd.html

We still need permission from @absidue and @coolstar before this change can be applied, thank you.
