### PR TITLE
uinotify: Allow notifications without a title

### DIFF
--- a/uinotify.m
+++ b/uinotify.m
@@ -98,10 +98,9 @@ int main(int argc, char *argv[]) {
 	}
 	argc -= optind;
 	argv += optind;
-
-	if (argc != 1) usage();
-
-	if (argv[0] == NULL) usage();
+	
+	if (argc != 1)
+		if (((body == NULL) && (subtitle == NULL)) || (argc > 1)) usage();
 
 	UNUserNotificationCenter *center = [[UNUserNotificationCenter alloc]
 		initWithBundleIdentifier:((bundleid != NULL)
@@ -110,7 +109,9 @@ int main(int argc, char *argv[]) {
 	UNMutableNotificationContent *content =
 		[[UNMutableNotificationContent alloc] init];
 
-	content.title = [NSString stringWithUTF8String:argv[0]];
+	if (argv[0] == NULL) {
+		if ((body == NULL) && (subtitle == NULL)) usage();
+	} else content.title = [NSString stringWithUTF8String:argv[0]];
 
 	if (body != NULL) content.body = [NSString stringWithUTF8String:body];
 

--- a/uinotify.m
+++ b/uinotify.m
@@ -111,7 +111,8 @@ int main(int argc, char *argv[]) {
 
 	if (argv[0] == NULL) {
 		if ((body == NULL) && (subtitle == NULL)) usage();
-	} else content.title = [NSString stringWithUTF8String:argv[0]];
+	} else
+		content.title = [NSString stringWithUTF8String:argv[0]];
 
 	if (body != NULL) content.body = [NSString stringWithUTF8String:body];
 


### PR DESCRIPTION
This change allows notifications to be sent that do not have a title but have a subtitle and/or body instead.