### PR TITLE
Exit from ecid function if the ecid couldn't be obtained

### DIFF
--- a/info/ecid.m
+++ b/info/ecid.m
@@ -4,6 +4,14 @@
 
 CFTypeRef MGCopyAnswer(CFStringRef);
 
+#ifndef NO_NLS
+#	include <libintl.h>
+#	define _(a) gettext(a)
+#	define PACKAGE "uikittools-ng"
+#else
+#	define _(a) a
+#endif
+
 int ecid(int argc, char **argv) {
 	bool hex = true;
 
@@ -22,7 +30,7 @@ int ecid(int argc, char **argv) {
 	uint64_t ecid;
 	CFNumberRef ecidRef = MGCopyAnswer(CFSTR("UniqueChipID"));
 	if (!ecidRef) {
-		printf("failed to get device ECID.\n");
+		fprintf(stderr, _("failed to get device ECID.\n"));
 		return 1;
 	}
 	CFNumberGetValue(ecidRef, kCFNumberSInt64Type, &ecid);

--- a/info/ecid.m
+++ b/info/ecid.m
@@ -30,7 +30,7 @@ int ecid(int argc, char **argv) {
 	uint64_t ecid;
 	CFNumberRef ecidRef = MGCopyAnswer(CFSTR("UniqueChipID"));
 	if (!ecidRef) {
-		fprintf(stderr, _("failed to get device ECID.\n"));
+		fprintf(stderr, _("Failed to get device ECID.\n"));
 		return 1;
 	}
 	CFNumberGetValue(ecidRef, kCFNumberSInt64Type, &ecid);

--- a/info/ecid.m
+++ b/info/ecid.m
@@ -21,6 +21,10 @@ int ecid(int argc, char **argv) {
 
 	uint64_t ecid;
 	CFNumberRef ecidRef = MGCopyAnswer(CFSTR("UniqueChipID"));
+	if (!ecidRef) {
+		printf("failed to get device ECID.\n");
+		return 1;
+	}
 	CFNumberGetValue(ecidRef, kCFNumberSInt64Type, &ecid);
 	printf(hex ? "0x%llX\n" : "%lld\n", ecid);
 	CFRelease(ecidRef);

--- a/po/uikittools-ng.pot
+++ b/po/uikittools-ng.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uikittools-ng 2.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-08 20:05+0300\n"
+"POT-Creation-Date: 2022-05-08 20:20+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -471,7 +471,7 @@ msgstr ""
 
 #: ../info/ecid.m:33
 #, c-format
-msgid "failed to get device ECID.\n"
+msgid "Failed to get device ECID.\n"
 msgstr ""
 
 #: ../info/locale.m:16

--- a/po/uikittools-ng.pot
+++ b/po/uikittools-ng.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uikittools-ng 2.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-21 22:53-0500\n"
+"POT-Creation-Date: 2022-05-08 20:05+0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -50,26 +50,26 @@ msgstr ""
 msgid "RebuildApplicationDatabases failed"
 msgstr ""
 
-#: ../mgask.m:33 ../uialert.m:200 ../uidisplay.m:403
+#: ../mgask.m:34 ../uialert.m:200 ../uidisplay.m:403
 #, c-format
 msgid "JSON formating failed: %s"
 msgstr ""
 
-#: ../mgask.m:98
+#: ../mgask.m:117
 #, c-format
-msgid "Usage: %s [-jpq] [--gssc] [--pretty] question ...\n"
+msgid "Usage: %s [-cjpq] [--gssc] [--pretty] question ...\n"
 msgstr ""
 
-#: ../mgask.m:122
+#: ../mgask.m:154
 #, c-format
 msgid "Cannot find key %s\n"
 msgstr ""
 
-#: ../mgask.m:136 ../uicache.m:253
+#: ../mgask.m:168 ../uicache.m:254
 msgid "true"
 msgstr ""
 
-#: ../mgask.m:136 ../uicache.m:253
+#: ../mgask.m:168 ../uicache.m:254
 msgid "false"
 msgstr ""
 
@@ -182,27 +182,27 @@ msgstr ""
 msgid "Contact the Procursus Team for support.\n"
 msgstr ""
 
-#: ../uicache.m:141
+#: ../uicache.m:142
 #, c-format
 msgid "uicache does not support App Store apps.\n"
 msgstr ""
 
-#: ../uicache.m:143
+#: ../uicache.m:144
 #, c-format
 msgid "Continuing anyway...\n"
 msgstr ""
 
-#: ../uicache.m:213
+#: ../uicache.m:214
 #, c-format
 msgid "Error: Unable to register %s\n"
 msgstr ""
 
-#: ../uicache.m:217
+#: ../uicache.m:218
 #, c-format
 msgid "Error: Unable to unregister %s\n"
 msgstr ""
 
-#: ../uicache.m:237
+#: ../uicache.m:238
 #, c-format
 msgid ""
 "Name: %s\n"
@@ -216,22 +216,22 @@ msgid ""
 "Removeable: %s\n"
 msgstr ""
 
-#: ../uicache.m:256 ../uicache.m:264
+#: ../uicache.m:257 ../uicache.m:265
 #, c-format
 msgid "URLScheme: %s\n"
 msgstr ""
 
-#: ../uicache.m:269
+#: ../uicache.m:270
 #, c-format
 msgid "%s is an invalid bundle id\n"
 msgstr ""
 
-#: ../uicache.m:373
+#: ../uicache.m:374
 #, c-format
 msgid "registering %s\n"
 msgstr ""
 
-#: ../uicache.m:378
+#: ../uicache.m:379
 #, c-format
 msgid "unregistering %s\n"
 msgstr ""
@@ -467,6 +467,11 @@ msgstr ""
 #, c-format
 msgid ""
 "Usage: %s [cfversion | ecid | locale | serial | uniqueid] [arguments ...]\n"
+msgstr ""
+
+#: ../info/ecid.m:33
+#, c-format
+msgid "failed to get device ECID.\n"
 msgstr ""
 
 #: ../info/locale.m:16


### PR DESCRIPTION
This pull request makes it so that, when the ECID can't be obtained in the ecid function (which is the case for x86 macs), it'll exit early and notify the user, rather than segfault like it does right now