### PR TITLE
Again fix the definition of xpc_pipe_routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ ifeq (,$(findstring macosx,$(CC) $(CFLAGS)))
 endif
 
 ldrestart: ldrestart.c ent.plist
-	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS)
+	$(CC) -fobjc-arc $(CFLAGS) $< -o $@ $(LDFLAGS)
 
 sbdidlaunch: sbdidlaunch.c ent.plist
-	$(CC) $(CFLAGS) $< -o $@ $(LDFLAGS) -framework CoreFoundation
+	$(CC) -fobjc-arc $(CFLAGS) $< -o $@ $(LDFLAGS) -framework CoreFoundation
 
 uialert: uialert.m strtonum.c ent.plist
 	$(CC) -fobjc-arc $(CFLAGS) $< $(word 2,$^) -o $@ $(LDFLAGS) -framework CoreFoundation

--- a/ldrestart.c
+++ b/ldrestart.c
@@ -18,7 +18,16 @@
 #	define LOCALEDIR "/usr/share/locale"
 #endif
 
+#if __has_feature(objc_arc)
+
+extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, __strong xpc_object_t *reply);
+
+#else
+
 extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, xpc_object_t *reply);
+
+#endif
+
 extern char *xpc_strerror(int);
 
 #define HANDLE_SYSTEM 0

--- a/ldrestart.c
+++ b/ldrestart.c
@@ -65,7 +65,7 @@ static int stopService(const char *ServiceName) {
 	xpc_dictionary_set_uint64(dict, "type", 1);
 	xpc_dictionary_set_string(dict, "name", ServiceName);
 
-	xpc_object_t *outDict = NULL;
+	xpc_object_t outDict = NULL;
 
 	struct xpc_global_data *xpc_gd =
 		(struct xpc_global_data *)_os_alloc_once_table[1].ptr;
@@ -96,7 +96,7 @@ int main() {
 	xpc_dictionary_set_uint64(dict, "type", 1);	 // set to 1
 	xpc_dictionary_set_bool(dict, "legacy", 1);	 // mandatory
 
-	xpc_object_t *outDict = NULL;
+	xpc_object_t outDict = NULL;
 
 	struct xpc_global_data *xpc_gd =
 		(struct xpc_global_data *)_os_alloc_once_table[1].ptr;

--- a/ldrestart.c
+++ b/ldrestart.c
@@ -19,13 +19,9 @@
 #endif
 
 #if __has_feature(objc_arc)
-
 extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, __strong xpc_object_t *reply);
-
 #else
-
 extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, xpc_object_t *reply);
-
 #endif
 
 extern char *xpc_strerror(int);

--- a/ldrestart.c
+++ b/ldrestart.c
@@ -18,8 +18,7 @@
 #	define LOCALEDIR "/usr/share/locale"
 #endif
 
-extern int xpc_pipe_routine(xpc_object_t *xpc_pipe, xpc_object_t *inDict,
-							xpc_object_t **out);
+extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, xpc_object_t *reply);
 extern char *xpc_strerror(int);
 
 #define HANDLE_SYSTEM 0

--- a/sbreload-launchd.c
+++ b/sbreload-launchd.c
@@ -16,13 +16,9 @@
 #endif
 
 #if __has_feature(objc_arc)
-
 extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, __strong xpc_object_t *reply);
-
 #else
-
 extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, xpc_object_t *reply);
-
 #endif
 
 extern char *xpc_strerror(int);

--- a/sbreload-launchd.c
+++ b/sbreload-launchd.c
@@ -15,7 +15,16 @@
 #	define LOCALEDIR "/usr/share/locale"
 #endif
 
+#if __has_feature(objc_arc)
+
+extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, __strong xpc_object_t *reply);
+
+#else
+
 extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, xpc_object_t *reply);
+
+#endif
+
 extern char *xpc_strerror(int);
 
 #define HANDLE_SYSTEM 0

--- a/sbreload-launchd.c
+++ b/sbreload-launchd.c
@@ -65,7 +65,7 @@ int stopService(const char *ServiceName) {
 	xpc_dictionary_set_uint64(dict, "type", 1);
 	xpc_dictionary_set_string(dict, "name", ServiceName);
 
-	xpc_object_t *outDict = NULL;
+	xpc_object_t outDict = NULL;
 
 	struct xpc_global_data *xpc_gd =
 		(struct xpc_global_data *)_os_alloc_once_table[1].ptr;
@@ -90,7 +90,7 @@ int updatePIDs() {
 	xpc_dictionary_set_uint64(dict, "type", 1);	 // set to 1
 	xpc_dictionary_set_bool(dict, "legacy", 1);	 // mandatory
 
-	xpc_object_t *outDict = NULL;
+	xpc_object_t outDict = NULL;
 
 	struct xpc_global_data *xpc_gd =
 		(struct xpc_global_data *)_os_alloc_once_table[1].ptr;

--- a/sbreload-launchd.c
+++ b/sbreload-launchd.c
@@ -15,8 +15,7 @@
 #	define LOCALEDIR "/usr/share/locale"
 #endif
 
-extern int xpc_pipe_routine(xpc_object_t *xpc_pipe, xpc_object_t *inDict,
-							xpc_object_t **out);
+extern int xpc_pipe_routine(xpc_object_t pipe, xpc_object_t message, xpc_object_t *reply);
 extern char *xpc_strerror(int);
 
 #define HANDLE_SYSTEM 0


### PR DESCRIPTION
In order to avoid a memory leak that only happens under ARC, `xpc_pipe_routine` needs a `__strong` qualifier on the `reply` argument. Don't ask how I know this, the answer is pain. 